### PR TITLE
Update Landing page and docs

### DIFF
--- a/docs/_data/sidebars/mydoc_sidebar.yml
+++ b/docs/_data/sidebars/mydoc_sidebar.yml
@@ -23,10 +23,10 @@ entries:
     output: web, pdf
     folderitems:
 
-    - title: Introduction to Kruize
-      url: /kruize_introduction.html
-      output: web, pdf
-      type: homepage
+#    - title: Introduction to Kruize
+#      url: /index.html
+#      output: web, pdf
+#      type: homepage
 
     - title: Getting Started
       url: /getting_started.html
@@ -40,7 +40,7 @@ entries:
     output: web, pdf
     folderitems:
 
-    - title: Autotune Release Notes
+    - title: Kruize Release Notes
       url: /autotune_release_notes.html
       output: web, pdf
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,8 +2,8 @@
 title: "Kruize Autotune"
 keywords: sample homepage
 sidebar: mydoc_sidebar
-permalink: index.html
-summary: These brief instructions will help you get started quickly with the kRUIZE. 
+permalink: kruize_autotune.html
+summary: These brief instructions will help you get started quickly with the kRUIZE.
 ---
 
 ## Overview
@@ -35,6 +35,3 @@ Kruize supports “autotune” mode that addresses complex user defined performa
 
 Kruize Autotune is a PoC only feature. However this has been used by Perf and Scale teams to tune the OS (Node Tuning Operator (NTO) Profiles), Apache Kafka service tuning, by Quarkus to get better performance, and currently ongoing collaboration with EAP as part of a sustainability initiative.
 
-
-
-{% include links.html %}

--- a/docs/pages/mydoc/autotune_release_notes.md
+++ b/docs/pages/mydoc/autotune_release_notes.md
@@ -1,5 +1,5 @@
 ---
-title: Autotune Release Notes
+title: Kruize Release Notes
 sidebar: mydoc_sidebar
 permalink: autotune_release_notes.html
 folder: mydoc

--- a/docs/pages/mydoc/kruize_introduction.md
+++ b/docs/pages/mydoc/kruize_introduction.md
@@ -1,7 +1,7 @@
 ---
 title: Kruize Introduction
 sidebar: mydoc_sidebar
-permalink: kruize_introduction.html
+permalink: index.html
 folder: mydoc
 ---
 

--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
     </div>
 
     <div class="community-call">
-        <u>Join our community call to explore more and interact with the Kruize team!</u>
+        <u>Stay tuned for upcoming community calls to explore more and interact with the Kruize team!</u>
     </div>
 
     <div class="hero">
@@ -36,7 +36,7 @@
             <h1>Optimize Your Kubernetes Costs</h1>
             <p>Monitor and reduce your Kubernetes cloud spending with real-time insights.</p>
             <a href="https://github.com/kruize/kruize-demos/tree/main/monitoring/local_monitoring">
-                <button class="cta-button" >Get Started</button>
+                <button class="cta-button">Get Started</button>
             </a>
         </div>
         <div class="hero-image">
@@ -54,45 +54,48 @@
     <div class="features">
         <h1 class="feature-heading">Kruize Features</h1>
 
-        <div class="feature">
-            <img src="assets/recommendations.png" alt="GPU Optimization" class="img-large">
-            <div class="feature-text">
+        <div class="features-grid">
+            <div class="feature-card">
+                <div class="feature-icon">📊</div>
                 <h2>Right-sizing</h2>
                 <p>Kruize can provide right-sizing recommendations for containers and namespaces.
                     Container right sizing includes CPU, Memory and Nvidia Accelerators.
-                    Namespace recommendations are in the form of limits for CPU and quota for memory. </p>
+                    Namespace recommendations are in the form of limits for CPU and quota for memory.</p>
             </div>
-        </div>
-        <div class="feature">
-            <img src="assets/box_plot.png" alt="Box Plots" class="img-large">
-            <div class="feature-text">
+
+            <div class="feature-card">
+                <div class="feature-icon">📈</div>
                 <h2>Box Plot Recommendation support</h2>
                 <p>Visualize cost distributions with detailed statistical insights.
                     Box Plots provides actual usage summary for the observed duration.</p>
             </div>
-        </div>
-        <div class="feature">
-            <img src="assets/gpu_recommendations.png" alt="Container NSP" >
-            <div class="feature-text">
+
+            <div class="feature-card">
+                <div class="feature-icon">🎮</div>
                 <h2>GPU Recommendations</h2>
                 <p>MIG Partitioning Recommendations are available from Kruize v0.1 onwards</p>
             </div>
-        </div>
-        <div class="feature">
-            <img src="assets/runtimes_recommendations.png" alt="Runtime Recommendations" >
-            <div class="feature-text">
+
+            <div class="feature-card">
+                <div class="feature-icon">⚙️</div>
                 <h2>Runtime Recommendations</h2>
-                <p>Kruize analyzes runtime metrics and provides optimal JVM settings, heap sizes, and GC configurations to improve Java application performance and efficiency.
-                </p>
+                <p>Kruize analyzes runtime metrics and provides optimal JVM settings, heap sizes, and GC configurations
+                    to improve Java application performance and efficiency.</p>
             </div>
-        </div>
-        <div class="feature">
-            <img src="assets/vpa_img.png" alt="Vertical Pod Autoscaler">
-            <div class="feature-text">
+
+            <div class="feature-card">
+                <div class="feature-icon">🔄</div>
                 <h2>Vertical Pod Autoscaler</h2>
                 <p>Kruize uses VPA under the covers to apply CPU and memory right sizing recommendations.
-                    Kruize supports two modes “auto” and “recreate” that correspond to the modes of VPA with the same
+                    Kruize supports two modes "auto" and "recreate" that correspond to the modes of VPA with the same
                     names.</p>
+            </div>
+
+            <div class="feature-card">
+                <div class="feature-icon">🎯</div>
+                <h2>Kruize Operator</h2>
+                <p>Kubernetes operator that automates the deployment and management of Kruize components, simplifying
+                    installation and ensuring seamless integration with your cluster.</p>
             </div>
         </div>
     </div>
@@ -117,10 +120,11 @@
 
 
     <div class="getting-started-wrapper">
-        <h2 style="text-align:center;">Get Up and Running in 5 Minutes</h2>
+        <h2 style="text-align:center;">Deploy and Start Optimizing in 5 Minutes</h2>
 
         <div class="getting-started">
-            <a href="https://github.com/kruize/kruize-demos/blob/main/monitoring/local_monitoring/ReadMe.md" style="text-decoration:none;">
+            <a href="https://github.com/kruize/kruize-demos/blob/main/monitoring/local_monitoring/ReadMe.md"
+                style="text-decoration:none;">
                 <div class="step-box">Getting Started With Kruize</div>
             </a>
         </div>
@@ -134,7 +138,7 @@
             <p>Copyright IBM Corp. 2025. All rights reserved.</p>
             <p>Terms | Privacy Policy</p>
         </div>
-        
+
         <!-- Center Section -->
         <div class="footer-center">
 
@@ -145,7 +149,8 @@
             <a href="mailto:team@kruize.com"><u>team@kruize.com</u></a>
             <div class="social-icons">
                 <a href="https://github.com/kruize/autotune"><img src="assets/github-icon.png" alt="GitHub"></a>
-                <a href="https://join.slack.com/t/kruizeworkspace/shared_invite/zt-2i2bs72qr-mfJU3uqcWXXSUv~O0~rbog"><img src="assets/slack-black.png" alt="Slack"></a>
+                <a href="https://join.slack.com/t/kruizeworkspace/shared_invite/zt-2i2bs72qr-mfJU3uqcWXXSUv~O0~rbog"><img
+                        src="assets/slack-black.png" alt="Slack"></a>
             </div>
         </div>
     </footer>


### PR DESCRIPTION
Update Kruize features section in Landing page and cosmetic fixes in Docs tab

## Summary by Sourcery

Revise the public website landing page feature section and update documentation navigation and titles to better reflect current Kruize positioning.

Documentation:
- Refresh the landing page copy, feature layout, and calls to action, including adding a Kruize Operator feature highlight.
- Update documentation sidebar entries, page permalinks, and release notes titles to consistently use Kruize naming and set the introduction page as the docs index.